### PR TITLE
Don't ignore root package dependencies

### DIFF
--- a/lib/visualize_packwerk/package_graph.rb
+++ b/lib/visualize_packwerk/package_graph.rb
@@ -32,10 +32,8 @@ module VisualizePackwerk
 
         violations = package_info.violations
         violations_by_package = violations.group_by(&:to_package_name).transform_values(&:count)
-        violations_by_package.delete('.') # remove root package violations
 
         dependencies = package_info.dependencies
-        dependencies.delete('.') # remove root package dependencies
 
         package_nodes << PackageNode.new(
           name: p.name,


### PR DESCRIPTION
The packs gem underlying this visualization ignores the root package by default (packages are by default only looked for in `packs/*`. So, the specific exclusion of the root package is not necessary anymore.

Going forward, if you do want to see the root package in your graph, add it to `packs.yml`, should it not already be in there ... or vice versa.