### PR TITLE
Fix bug if pack does not exist

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    visualize_packwerk (0.2.0)
+    visualize_packwerk (0.2.1)
       code_ownership
       packs
       parse_packwerk

--- a/lib/visualize_packwerk/package_graph.rb
+++ b/lib/visualize_packwerk/package_graph.rb
@@ -16,7 +16,7 @@ module VisualizePackwerk
     sig { params(package_nodes: T::Set[PackageNode]).void }
     def initialize(package_nodes:)
       @package_nodes = package_nodes
-      @index_by_name = T.let({}, T::Hash[String, PackageNode])
+      @index_by_name = T.let({}, T::Hash[String, T.nilable(PackageNode)])
     end
 
     sig { returns(PackageGraph) }
@@ -46,9 +46,9 @@ module VisualizePackwerk
       PackageGraph.new(package_nodes: package_nodes)
     end
 
-    sig { params(name: String).returns(PackageNode) }
+    sig { params(name: String).returns(T.nilable(PackageNode)) }
     def package_by_name(name)
-      @index_by_name[name] ||= T.must(package_nodes.find { |node| node.name == name })
+      @index_by_name[name] ||= package_nodes.find { |node| node.name == name }
     end
   end
 end

--- a/lib/visualize_packwerk/team_graph.rb
+++ b/lib/visualize_packwerk/team_graph.rb
@@ -26,7 +26,9 @@ module VisualizePackwerk
         package_nodes_for_team.map(&:violations_by_package).each do |new_violations_by_package|
           new_violations_by_package.each do |pack_name, count|
             # We first get the pack owner of the violated package
-            other_team = package_graph.package_by_name(pack_name).team_name
+            other_package = package_graph.package_by_name(pack_name)
+            next if other_package.nil?
+            other_team = other_package.team_name
             violations_by_team[other_team] ||= 0
             # Then we add the violations on that team together
             # TODO: We may want to ignore this if team == other_team to avoid arrows pointing to self, but maybe not!
@@ -36,7 +38,9 @@ module VisualizePackwerk
 
         dependencies = Set.new
         package_nodes_for_team.map(&:dependencies).reduce(Set.new, :+).each do |dependency|
-          dependencies << package_graph.package_by_name(dependency).team_name
+          other_pack = package_graph.package_by_name(dependency)
+          next if other_pack.nil?
+          dependencies << other_pack.team_name
         end
 
         team_nodes << TeamNode.new(

--- a/visualize_packwerk.gemspec
+++ b/visualize_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "visualize_packwerk"
-  spec.version       = '0.2.0'
+  spec.version       = '0.2.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A gem to visualize connections in a Rails app that uses Packwerk'


### PR DESCRIPTION
Since we switched to using `packs`, some packwerk package relationships might lead to a pack that does not exist. For example, if the root pack is not specified as a "pack" in `packs.yml`, then we get an error due to not being able to find the pack.

Eventually, we probably want to improve this by ONLY using packs or packwerk, but for now, we just skip when the pack cannot be found.
