### PR TITLE
Add AGENTS.md and CLAUDE.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this project is
+
+`visualize_packs` is a Ruby gem that generates visual diagrams of pack connections in a Rails application using [packs](https://github.com/rubyatscale/packs) and packwerk. It helps teams understand dependency relationships and identify architectural issues.
+
+## Commands
+
+```bash
+bundle install
+
+# Run all tests (RSpec)
+bundle exec rspec
+
+# Run a single spec file
+bundle exec rspec spec/path/to/spec.rb
+
+# Type checking (Sorbet)
+bundle exec srb tc
+```
+
+## Architecture
+
+- `lib/visualize_packs.rb` — entry point; reads pack configuration and produces graph output
+- `lib/visualize_packs/` — core logic: graph building, layout, and rendering (e.g. to DOT/SVG)
+- `spec/` — RSpec tests; `spec/fixtures/` holds sample pack configurations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# AGENTS.md
-
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## What this project is
@@ -25,4 +23,4 @@ bundle exec srb tc
 
 - `lib/visualize_packs.rb` — entry point; reads pack configuration and produces graph output
 - `lib/visualize_packs/` — core logic: graph building, layout, and rendering (e.g. to DOT/SVG)
-- `spec/` — RSpec tests; `spec/fixtures/` holds sample pack configurations
+- `spec/` — RSpec tests; `spec/sample_app1/` contains a sample pack-structured application used in tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with codebase guidance for AI coding agents (commands, architecture)
- Adds `CLAUDE.md` containing just `@AGENTS.md`, following the [Claude Code best practice](https://code.claude.com/docs/en/claude-code-on-the-web#best-practices) of sharing a single instruction file across agents

This makes the same guidance available to Claude Code (via `CLAUDE.md` import) and other agents like Codex that look for `AGENTS.md`.