### PR TITLE
Fix typos and grammatical issues

### DIFF
--- a/lib/visualize_packs/options_parser.rb
+++ b/lib/visualize_packs/options_parser.rb
@@ -26,13 +26,13 @@ class OptionsParser
       opt.on('--no-node-todos', "Don't show package-based todos") { |o| options.show_node_todos = false }
 
       opt.on('--focus-pack=STRING', "Focus on a specific pack(s). Comma-separated list of packs. Wildcards supported: 'packs/*'") { |o| options.focus_pack = o.to_s.split(",") }
-      opt.on('--focus-pack-edge-mode=STRING', "If focus-pack is set, this shows only between focussed packs (when set to none) or the edges into / out of / in and out of the focus packs to non-focus packs (which will be re-added to the graph). One of #{FocusPackEdgeDirection.values.map &:serialize}") { |o| options.show_only_edges_to_focus_pack = FocusPackEdgeDirection.deserialize(o) }
-      opt.on('--exclude-packs=', "Exclude listed packs from diagram. If used with include you will get all included that are not excluded. Wildcards support: 'packs/ignores/*'") { |o| options.exclude_packs = o.to_s.split(",") }
+      opt.on('--focus-pack-edge-mode=STRING', "If focus-pack is set, this shows only between focused packs (when set to none) or the edges into / out of / in and out of the focus packs to non-focus packs (which will be re-added to the graph). One of #{FocusPackEdgeDirection.values.map &:serialize}") { |o| options.show_only_edges_to_focus_pack = FocusPackEdgeDirection.deserialize(o) }
+      opt.on('--exclude-packs=', "Exclude listed packs from diagram. If used with include you will get all included that are not excluded. Wildcards supported: 'packs/ignores/*'") { |o| options.exclude_packs = o.to_s.split(",") }
 
       opt.on('--roll-nested-into-parent-packs', "Don't show nested packs (not counting root). Connect edges to top-level pack instead") { |o| options.roll_nested_into_parent_packs = true }
       opt.on('--no-nesting-arrows', "Don't draw relationships between parents and nested packs") { |o| options.show_nested_relationships = false }
 
-      opt.on('--remote-base-url=STRING', "Link pack packs to a URL (affects graphviz SVG generation)") { |o| options.remote_base_url = o }
+      opt.on('--remote-base-url=STRING', "Link packs to a URL (affects graphviz SVG generation)") { |o| options.remote_base_url = o }
 
       opt.on('--title=STRING', "Set a custom diagram title") { |o| options.title = o }
 

--- a/spec/visualize_packs_spec.rb
+++ b/spec/visualize_packs_spec.rb
@@ -429,10 +429,10 @@ RSpec.describe "VisualizePacks" do
       #Filtering + excluding (including wildcards)
       ['a1234c',   true_, true_, 'dpav', 'a',  '     ', '               ',           nil,         %w(packs/a/1), 'a 234c', 'exclude_packs removes node'],
       ['a1234c',   true_, true_, 'dpav', 'a',  '     ', '               ',           nil,         %w(packs/a/*), 'a  34c', 'exclude_packs with wildcard removes nodes'],
-      ['a1234c',   true_, true_, 'dpav', 'a',  '     ', '               ',           nil, %w(packs/a packs/a/*), '   34c', 'exclude_packs with multiple exludes works'],
-      ['a1234c',   true_, true_, 'dpav', 'a',  '     ', '               ',   %w(packs/a),           %w(packs/a), '      ', 'exclude_packs exludes focus'],
-      ['a1234c',   true_, true_, 'dpav', 'a',  'a1   ', '               ',   %w(packs/a),           %w(packs/a), ' 1    ', 'exclude_packs exludes focus but keeps dependency'],
-      ['a1234c',   true_, true_, 'dpav', 'a',  '     ', '            ad1',   %w(packs/a),           %w(packs/a), ' 1    ', 'exclude_packs exludes focus but keeps todo'],
+      ['a1234c',   true_, true_, 'dpav', 'a',  '     ', '               ',           nil, %w(packs/a packs/a/*), '   34c', 'exclude_packs with multiple excludes works'],
+      ['a1234c',   true_, true_, 'dpav', 'a',  '     ', '               ',   %w(packs/a),           %w(packs/a), '      ', 'exclude_packs excludes focus'],
+      ['a1234c',   true_, true_, 'dpav', 'a',  'a1   ', '               ',   %w(packs/a),           %w(packs/a), ' 1    ', 'exclude_packs excludes focus but keeps dependency'],
+      ['a1234c',   true_, true_, 'dpav', 'a',  '     ', '            ad1',   %w(packs/a),           %w(packs/a), ' 1    ', 'exclude_packs excludes focus but keeps todo'],
       #Filtering + dependencies + todos + excluding
       ['a1234c',   true_, true_, ' pa ', 'o',  'a1 2a', '    ad3 4aa apc',   %w(packs/a),           %w(packs/a), ' 1   c', 'combination of todo filtering, edge mode, focus, and exclude works'],
      ].each do |c|


### PR DESCRIPTION
## Summary
- Fix typo: `exludes` -> `excludes` in four test description strings
- Fix additional grammatical issues found in CLI help strings

## Changes
- Commit 1: Fix confirmed typos found by `typos` tool (`exludes` -> `excludes` in spec/visualize_packs_spec.rb lines 432-435)
- Commit 2: Fix grammar in CLI option help strings: `focussed` -> `focused`, `Wildcards support:` -> `Wildcards supported:`, and `Link pack packs` -> `Link packs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)