### PR TITLE
Require Ruby >= 3.3 and update CI Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.1
-          - 3.2
           - 3.3
+          - 3.4
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "RSpec tests: Ruby ${{ matrix.ruby }}"
@@ -32,9 +31,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.1
-          - 3.2
           - 3.3
+          - 3.4
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "Visual Regression Suite: Ruby ${{ matrix.ruby }}"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,4 +79,4 @@ DEPENDENCIES
   visualize_packs!
 
 BUNDLED WITH
-   2.5.10
+   4.0.15

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ bundle exec visualize_packs --help
 
 ## Contributing
 
-To contribute, install graphviz (and the `dot` command) and imagemagick. You must also have Ruby 3.2.2 and bundler installed. Then
+To contribute, install graphviz (and the `dot` command) and imagemagick. You must also have Ruby 3.3 and bundler installed. Then
 
 ```
 ./spec/test.sh

--- a/visualize_packs.gemspec
+++ b/visualize_packs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir['README.md', 'lib/**/*', "bin/**/*"]
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.add_dependency 'bigdecimal'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
## Summary

Bumps the minimum supported Ruby version to 3.3 (Ruby 3.2 is now EOL) and refreshes the CI test matrices to the currently supported set (3.3 and 3.4).

### Changes
- **`visualize_packs.gemspec`**: `required_ruby_version` raised from `'>= 2.7'` to `'>= 3.3'`.
- **`.github/workflows/ci.yml`**: In both the `rspec` and `visual_regression_suite` job matrices, removed Ruby `3.1` and `3.2` and added `3.4`, leaving the supported set `[3.3, 3.4]`. The single-pinned `static_type_check` step (already `'3.3'`) was left unchanged.
- **`README.md`**: Updated the contributing minimum-version statement from "Ruby 3.2.2" to "Ruby 3.3".

## Motivation

This resolves the Ruby version restrictions from rubyatscale/pack_stats#56, where continuing to support EOL Ruby versions forced the use of older/vulnerable transitive dependencies. Dropping EOL Ruby (3.2) and standardizing on the supported 3.3/3.4 set unblocks newer dependency versions.



## Bundler

Also bumps `BUNDLED WITH` in `Gemfile.lock` to bundler **4.0.15** (latest). The previously pinned bundler version crashes on Ruby `head` (`NameError: uninitialized constant Pathname::SEPARATOR_PAT`) — see [this failing run](https://github.com/rubyatscale/code_manifest/actions/runs/28200903631/job/83539858239?pr=12). Pinning the current bundler resolves it.