### PR TITLE
ci: test against Ruby 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.3
-          - 3.4
+          - '3.3'
+          - '3.4'
+          - '4.0'
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "RSpec tests: Ruby ${{ matrix.ruby }}"
@@ -31,8 +32,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.3
-          - 3.4
+          - '3.3'
+          - '3.4'
+          - '4.0'
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "Visual Regression Suite: Ruby ${{ matrix.ruby }}"
@@ -54,6 +56,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: '3.3'
+          ruby-version: '4.0'
       - name: Run static type checks
         run: bundle exec srb tc


### PR DESCRIPTION
## What
Adds **Ruby 4.0** to the CI build matrix so this gem is tested against the latest Ruby.

## Changes
- Add `'4.0'` to the test matrix.
- Run the fixed-version `Type Check` job on Ruby 4.0 (was 3.3).
- Quote all Ruby version numbers (`'3.3'`, `'3.4'`, `'4.0'`) for consistency and to avoid YAML float coercion.

## Why
Most rubyatscale repos already test Ruby 4.0 (via the shared reusable CI workflow). This brings the remaining custom-matrix repos in line.
