### PR TITLE
Bump loader-utils to 2.0.3+ (transitive) to fix critical prototype pollution alert

### DIFF
--- a/d3_graph_generator/package.json
+++ b/d3_graph_generator/package.json
@@ -13,6 +13,14 @@
     "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
+  "resolutions": {
+    "react-scripts/@pmmmwh/react-refresh-webpack-plugin/loader-utils": "^2.0.3",
+    "react-scripts/@svgr/webpack/loader-utils": "^2.0.3",
+    "react-scripts/babel-loader/loader-utils": "^2.0.3",
+    "react-scripts/file-loader/loader-utils": "^2.0.3",
+    "react-scripts/resolve-url-loader/loader-utils": "^2.0.3",
+    "react-scripts/resolve-url-loader/adjust-sourcemap-loader/loader-utils": "^2.0.3"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/d3_graph_generator/yarn.lock
+++ b/d3_graph_generator/yarn.lock
@@ -6483,10 +6483,10 @@ loader-runner@^4.3.2:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.2.tgz#9913d3a15971f8f635915e601fb5c9d495d918e9"
   integrity sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==
 
-loader-utils@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
-  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
+loader-utils@^2.0.0, loader-utils@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
@@ -8072,7 +8072,7 @@ regenerate@^1.4.2:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
+regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
## Summary

Fixes Dependabot alert [#3](https://github.com/rubyatscale/visualize_packs/security/dependabot/3) (critical): `loader-utils` prototype pollution, vulnerable range `>=2.0.0 <2.0.3`.

`loader-utils@2.0.2` lives in `d3_graph_generator/yarn.lock` and is purely transitive, hoisted through six react-scripts-bundled loaders (`react-refresh-webpack-plugin`, `@svgr/webpack`, `babel-loader`, `file-loader`, `resolve-url-loader`, `adjust-sourcemap-loader`), all of which request `^2.0.0`.

Rather than add a direct dependency to break the vulnerable range, this uses yarn's `resolutions` field, scoped to those six requester paths, to force the hoisted instance up to 2.0.4. There's a separate, unrelated `loader-utils@3.2.0` resolved for `react-dev-utils` (outside the vulnerable range) that this deliberately leaves alone, a bare `"loader-utils"` resolution key would have collapsed both instances into one and silently downgraded that unrelated 3.x install.

## Verification

`yarn why loader-utils` before:
```
=> Found "loader-utils@2.0.2"
info Has been hoisted to "loader-utils"
   - Hoisted from "react-scripts#@pmmmwh#react-refresh-webpack-plugin#loader-utils"
   - Hoisted from "react-scripts#@svgr#webpack#loader-utils"
   - Hoisted from "react-scripts#babel-loader#loader-utils"
   - Hoisted from "react-scripts#file-loader#loader-utils"
   - Hoisted from "react-scripts#resolve-url-loader#loader-utils"
   - Hoisted from "react-scripts#resolve-url-loader#adjust-sourcemap-loader#loader-utils"
=> Found "react-dev-utils#loader-utils@3.2.0"
```

`yarn why loader-utils` after:
```
=> Found "loader-utils@2.0.4"
info Has been hoisted to "loader-utils"
   (same six requesters)
=> Found "react-dev-utils#loader-utils@3.2.0"   <- unchanged
```

`git diff` touches only `d3_graph_generator/package.json` (the `resolutions` addition) and `d3_graph_generator/yarn.lock`.

This repo's CI (`ci.yml`) doesn't build or test the `d3_graph_generator` subproject at all, it's a standalone dev tool invoked manually via `yarn start`. I ran `yarn build` locally to sanity check and it fails on both this branch and `main` with an unrelated pre-existing error (`@babel/helper-compilation-targets: 'opera_mobile' is not a valid target`), a stale `caniuse-lite`/browserslist issue in this old CRA setup, unrelated to loader-utils and out of scope here.

## Test plan

- [x] `yarn why loader-utils` confirms hoisted instance is now 2.0.4, all six requesters satisfied
- [x] Confirmed the unrelated `react-dev-utils` `loader-utils@3.2.0` block is untouched in the lockfile diff
- [x] Confirmed `yarn build` failure is pre-existing on `main` (unrelated to this change)