### PR TITLE
Fix missing-workflow-permissions alerts and integrate zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       bundler:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -16,3 +18,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       bundler:
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,6 @@
 name: CD
 
-on:
+on: # zizmor: ignore[dangerous-triggers] deploy-after-CI-passes is the standard rubyatscale release pattern; the called workflow only tags/publishes on main
   workflow_run:
     workflows: [CI]
     types: [completed]
@@ -8,5 +8,7 @@ on:
 
 jobs:
   call-workflow-from-shared-config:
-    uses: rubyatscale/shared-config/.github/workflows/cd.yml@main
+    permissions:
+      contents: write
+    uses: rubyatscale/shared-config/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses,secrets-inherit] internal reusable workflow tracked at @main by convention so shared-config updates propagate automatically; environments are managed by callers
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   rspec:
     runs-on: ubuntu-latest
@@ -19,9 +22,11 @@ jobs:
       BUNDLE_GEMFILE: Gemfile
     name: "RSpec tests: Ruby ${{ matrix.ruby }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
@@ -39,9 +44,11 @@ jobs:
       BUNDLE_GEMFILE: Gemfile
     name: "Visual Regression Suite: Ruby ${{ matrix.ruby }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
@@ -51,9 +58,11 @@ jobs:
     name: "Type Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
           ruby-version: '4.0'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,14 +33,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.37.3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3.37.3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,4 +5,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   call-workflow-from-shared-config:
-    uses: rubyatscale/shared-config/.github/workflows/stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: rubyatscale/shared-config/.github/workflows/stale.yml@main # zizmor: ignore[unpinned-uses] internal reusable workflow tracked at @main by convention so shared-config updates propagate automatically

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,4 +6,6 @@ on:
       - opened
 jobs:
   call-workflow-from-shared-config:
-    uses: rubyatscale/shared-config/.github/workflows/triage.yml@main
+    permissions:
+      issues: write
+    uses: rubyatscale/shared-config/.github/workflows/triage.yml@main # zizmor: ignore[unpinned-uses] internal reusable workflow tracked at @main by convention so shared-config updates propagate automatically

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7


### PR DESCRIPTION
## Summary
Resolves 6 of the 7 open code scanning alerts (https://github.com/rubyatscale/visualize_packs/security/code-scanning), all `actions/missing-workflow-permissions` findings on workflow jobs that had no explicit `permissions:` block and so defaulted to the repository's token permissions:

| Alert | File | Fix |
|---|---|---|
| #8, #9, #6 | `ci.yml` (3 jobs) | root-level `contents: read` — checkout + `bundle exec` only, nothing writes |
| #3 | `cd.yml` | `contents: write` on the caller job — the called reusable workflow pushes a release tag (`discourse/publish-rubygems-action`) and creates a GitHub release (`gh release create`), both need `contents: write` |
| #1 | `stale.yml` | `issues: write` + `pull-requests: write` — required by `actions/stale` |
| #2 | `triage.yml` | `issues: write` — matches what the called reusable workflow's own job declares |

The 7th alert (`js/functionality-from-untrusted-source`, the insecure `http://d3js.org/d3.v3.min.js` CDN tag) was already fixed by #112 (merged), which deleted the file that alert pointed at — CodeQL just hasn't rescanned `main` yet, so it still shows as open.

Also adds `.github/workflows/zizmor.yml`, copied from `shared-config`'s existing zizmor integration (the org's canonical pattern — this is the first consumer repo to adopt it). Running it locally against this repo's own workflows surfaced real findings beyond CodeQL's coverage, fixed here so the new job starts green:
- Unpinned `actions/checkout@v4` / `ruby/setup-ruby@v1` in `ci.yml` — pinned to SHA, matching `codeql.yml`'s existing convention.
- Missing `persist-credentials: false` on checkout steps in `ci.yml` and `codeql.yml`.
- A stale version comment in `codeql.yml` (said `# v3.37.3`, the SHA is actually `v4.37.3` — a leftover from an earlier find-and-replace across the org).
- Three findings suppressed with `# zizmor: ignore[...]` for deliberate, org-wide conventions rather than bugs: `workflow_run`-triggered CD (`dangerous-triggers`), unpinned `@main` references to `shared-config`'s reusable workflows (`unpinned-uses` — pinning these would defeat the point of centralizing them), and `secrets: inherit` on the `cd.yml` caller (`secrets-inherit`, matching `shared-config`'s own precedent).

Verified with `zizmor .github/workflows/`, both offline and with `--gh-token` (online mode catches additional findings, like the stale version comment, that offline mode misses): 0 findings.

## ⚠️ Separate, pre-existing issue found during verification (not fixed by this PR)
Independent verification surfaced a real, currently-active bug in **`shared-config`'s own `cd.yml`** (not touched by this diff): its checkout step sets `persist-credentials: false`, but `discourse/publish-rubygems-action`'s `rake release` step does a raw `git push` that depends on that persisted credential. This means granting `contents: write` here is *necessary* but not *sufficient* — the actual deploy will still fail.

This isn't hypothetical: `rubyatscale/danger-migrations` (which calls the same `shared-config/cd.yml@main`) has failed 9 of its last 10 CD runs since 2026-04-14 with `fatal: could not read Username for 'https://github.com'`. `visualize_packs`'s next real gem release will very likely hit the same failure. Fixing it requires a change to `shared-config` itself (e.g. dropping `persist-credentials: false` on that checkout step, or re-authenticating before the push), which is out of scope for this PR.

## Test plan
- [x] `zizmor .github/workflows/` — 0 findings, offline and online
- [x] All 6 changed/added YAML files parse correctly
- [x] Each permission grant independently verified against what the called reusable workflow / action actually requires (not just copy-pasted from CodeQL's generic suggestion)
- [ ] Confirm alert #7 auto-closes once CodeQL rescans `main`